### PR TITLE
docs: Update README.md to add AWS endpoint URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ rustfs-mcp --log-level debug --region us-west-2
     "rustfs-mcp": {
       "command": "/path/to/rustfs-mcp",
       "args": [
+        "--endpoint-url", "your_url",
         "--access-key-id", "your_access_key",
         "--secret-access-key", "your_secret_key",
         "--region", "us-west-2",
@@ -140,6 +141,7 @@ rustfs-mcp --log-level debug --region us-west-2
     "rustfs-mcp": {
       "command": "/path/to/rustfs-mcp",
       "env": {
+        "AWS_ENDPOINT_URL": "your_url",
         "AWS_ACCESS_KEY_ID": "your_access_key",
         "AWS_SECRET_ACCESS_KEY": "your_secret_key",
         "AWS_REGION": "us-east-1"


### PR DESCRIPTION
Instructions for configuring AWS endpoint URLs through command-line parameters and environment variables have been added, to maintain consistency with other AWS credential configuration methods

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Summary of Changes
Added configuration instructions for AWS endpoint URLs via command-line parameters and environment variables. This update maintains consistency with existing AWS credential configuration methods (such as AWS_ACCESS_KEY_ID , AWS_SECRET_ACCESS_KEY , etc.), providing users with a unified approach to configuring AWS connectivity options.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
This change enables users to configure custom AWS endpoint URLs (useful for S3-compatible services like MinIO, local AWS development with LocalStack, or connecting to AWS China regions) through familiar configuration methods, aligning with how other AWS credentials are handled in the project.
log:2026-04-18T01:44:56.476+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#onClose Disconnected.
2026-04-18T01:44:56.476+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#stop Stopped.
2026-04-18T01:44:56.537+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#start Connecting with config... {"command":"C:\\Users\\16857\\Documents\\code\\mcp\\target\\release\\rustfs-mcp","env":{"AWS_ENDPOINT_URL":"http://192.168.124.5:9000","AWS_ACCESS_KEY_ID":"VaOQiWSD98K7LPyjtTYR","AWS_SECRET_ACCESS_KEY":"KxSeiBavHO4PtNVG2DhemRt7KdwryOfFopaVaF1n","AWS_REGION":"us-east-1"}}
2026-04-18T01:44:56.539+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPClient#start Start With StdioServerParameters {"command":"C:\\Users\\16857\\Documents\\code\\mcp\\target\\release\\rustfs-mcp","args":[],"cwd":"C:\\Users\\16857","stderr":"pipe","env_keys":["AHA_CHROME_CRASHPAD_PIPE_NAME","ALLUSERSPROFILE","APPDATA","APP_REGION","COMPUTERNAME","ComSpec","CommonProgramFiles","CommonProgramFiles(x86)","CommonProgramW6432","DriverData","EFC_10112_1262719628","EFC_10112_1592913036","EFC_10112_2283032206","EFC_10112_2397410445","EFC_10112_344590478","EFC_10112_3789132940","ELECTRON_FORCE_IS_PACKAGED","ELECTRON_RUN_AS_NODE","FPS_BROWSER_APP_PROFILE_STRING","FPS_BROWSER_USER_PROFILE_STRING","HOMEDRIVE","HOMEPATH","ICUBE_APP_VERSION","ICUBE_BUILD_TIME","ICUBE_BUILD_VERSION","ICUBE_CODEMAIN_SESSION","ICUBE_ELECTRON_PATH","ICUBE_ENABLE_MARSCODE_NLS","ICUBE_IS_ELECTRON","ICUBE_MACHINE_ID","ICUBE_MARSCODE_VERSION","ICUBE_PRODUCT_PROVIDER","ICUBE_PROVIDER","ICUBE_PROXY_HOST","ICUBE_QUALITY","ICUBE_USE_IPV6","ICUBE_VSCODE_VERSION","IGCCSVC_DB","LEVEL_ZERO_V1_SDK_PATH","LOCALAPPDATA","LOGONSERVER","NUMBER_OF_PROCESSORS","OS","OneDrive","OneDriveConsumer","PATHEXT","POSH_INSTALLER","POSH_THEMES_PATH","PROCESSOR_ARCHITECTURE","PROCESSOR_IDENTIFIER","PROCESSOR_LEVEL","PROCESSOR_REVISION","PSModulePath","PUBLIC","Path","ProgramData","ProgramFiles","ProgramFiles(x86)","ProgramW6432","SESSIONNAME","SystemDrive","SystemRoot","TEMP","TMP","TRAE_CONFIG_CHANNEL","USERDOMAIN","USERDOMAIN_ROAMINGPROFILE","USERNAME","USERPROFILE","VBOX_MSI_INSTALL_PATH","VSCODE_BUILTIN_EXTENSIONS_PATH","VSCODE_CODE_CACHE_PATH","VSCODE_CRASH_REPORTER_PROCESS_TYPE","VSCODE_CWD","VSCODE_ENV_PREPEND","VSCODE_ESM_ENTRYPOINT","VSCODE_EXTENSIONS_PATH","VSCODE_HANDLES_UNCAUGHT_ERRORS","VSCODE_IPC_HOOK","VSCODE_L10N_BUNDLE_LOCATION","VSCODE_NLS_CONFIG","VSCODE_PID","VSCODE_RUN_IN_ELECTRON","ZES_ENABLE_SYSMAN","isArchMatched","windir","AWS_ENDPOINT_URL","AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY","AWS_REGION"],"path":"c:\\Users\\16857\\.trae-cn\\tools\\trae-gopls\\current;c:\\Users\\16857\\.trae-cn\\sdks\\workspaces\\ada0e3aa\\versions\\node\\current;c:\\Users\\16857\\.trae-cn\\sdks\\versions\\node\\current;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\nodejs\\;C:\\Program Files\\Git\\cmd;C:\\Users\\16857\\Documents\\sanshu;C:\\Users\\16857\\.cargo\\bin;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Python314\\Scripts\\;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Python314\\;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Launcher\\;C:\\Users\\16857\\AppData\\Local\\Programs\\oh-my-posh\\bin\\;C:\\Users\\16857\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\16857\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Schniz.fnm_Microsoft.Winget.Source_8wekyb3d8bbwe;C:\\Users\\16857\\AppData\\Roaming\\npm;C:\\Users\\16857\\AppData\\Local\\Microsoft\\WinGet\\Packages\\pnpm.pnpm_Microsoft.Winget.Source_8wekyb3d8bbwe;C:\\Users\\16857\\AppData\\Local\\Microsoft\\WinGet\\Packages\\astral-sh.uv_Microsoft.Winget.Source_8wekyb3d8bbwe;c:\\Users\\16857\\AppData\\Local\\Programs\\Trae CN\\resources\\app\\bin\\lib;C:\\Users\\16857\\.trae-cn\\tools\\uv\\latest;C:\\Users\\16857\\scoop\\shims;C:\\ProgramData\\chocolatey\\bin;C:\\Program Files\\nodejs;C:\\Program Files (x86)\\nodejs;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Python310;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Python39;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Python38;C:\\Users\\16857\\AppData\\Local\\Programs\\Python\\Python37;C:\\Program Files\\Python;C:\\Users\\16857\\Anaconda3"}
2026-04-18T01:44:56.592+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#start Connected.
2026-04-18T01:44:56.593+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#listTools Listing tools...
2026-04-18T01:44:56.594+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#listTools Got tools: create_bucket, delete_bucket, get_object, list_buckets, list_objects, upload_file
2026-04-18T01:45:06.292+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#listTools Listing tools...
2026-04-18T01:45:06.293+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#listTools Got tools: create_bucket, delete_bucket, get_object, list_buckets, list_objects, upload_file
2026-04-18T01:45:06.293+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#callTool (list_buckets): {}
2026-04-18T01:45:06.380+08:00 [info] [mcp.config.usrlocalmcp.rustfs-mcp] MCPServerManager#callTool (list_buckets) result: {"content":[{"type":"text","text":"Found 1 S3 bucket(s):\n\n1. **nexushub**\n   - Created: 2026-04-17T17:21:50.247Z\n\n---\nTotal buckets: 1\nNote: Only buckets accessible with the current AWS credentials are shown."}],"isError":false}

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
